### PR TITLE
Fixed importBuffer,  now checking new API result

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,10 +277,10 @@ class SevdeskVoucherImporter {
         }
         
         // handle the result document
-        if (!resObj.document || !resObj.document.id)
+        if (!resObj.voucher || !resObj.voucher.document || !resObj.voucher.document.id)
             throw new Error(`Failed to extract document from response [4]: ${JSON.stringify(resObj)}`);
 
-        this.newDocumentId = parseInt(resObj.document.id);
+        this.newDocumentId = parseInt(resObj.voucher.document.id);
 
         this.debug(`Successfully saved voucher: ${this.newDocumentId}`);
     }


### PR DESCRIPTION
The [Sevdesk API saveVoucher](https://my.sevdesk.de/swaggerUI/index.html#/Voucher/saveVoucher) seems to have changed in the last couple of days. It now returns a sub-property called `voucher` instead of returning the document object at top level.

This little change fixes the current implementation. Tests are green again.
